### PR TITLE
added 'pretty' reporting for easier readability and adds html report

### DIFF
--- a/src/test/java/net/hpe/TestRunner.java
+++ b/src/test/java/net/hpe/TestRunner.java
@@ -7,7 +7,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(OctaneCucumber.class)
 @CucumberOptions(plugin = {"junit:junitResults.xml"},
-                 features = "src/test/resources/features")
+        features = "src/test/resources/features",
+        format= {"pretty", "html:target/cucumber-pretty-report"})
 public class TestRunner {
 
 }


### PR DESCRIPTION
produces a 'pretty' cucumber report in the log window so easier to read along with an html report in the target folder.

Example of the output (color coded in intellij)
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running net.mf.presales.LeanFtTest
#Auto generated NGA revision tag
@TID8021REV0.2.0
Feature: Advantage Online
  verify multiple scenarios

  Scenario Outline: verify mice color # advantage.feature:6
    Given I am in the site
    And I select the Mice category
    When I filter by "<color>" color
    Then the mouse price is "<price>"

    Examples: 

  @TID8021REV0.2.0
  Scenario Outline: verify mice color # advantage.feature:14
    Given I am in the site            # AdvantageStepDefinitions.i_am_in_the_site()
    And I select the Mice category    # AdvantageStepDefinitions.i_select_the_Mice_category()
    When I filter by "white" color    # AdvantageStepDefinitions.iFilterByColor(String)
    Then the mouse price is "$29.99"  # AdvantageStepDefinitions.the_mouse_price_is(String)

  @TID8021REV0.2.0
  Scenario Outline: verify mice color # advantage.feature:15
    Given I am in the site            # AdvantageStepDefinitions.i_am_in_the_site()
    And I select the Mice category    # AdvantageStepDefinitions.i_select_the_Mice_category()
    When I filter by "purple" color   # AdvantageStepDefinitions.iFilterByColor(String)
    Then the mouse price is "$9.99"   # AdvantageStepDefinitions.the_mouse_price_is(String)
      java.lang.AssertionError
      	at org.junit.Assert.fail(Assert.java:86)
      	at org.junit.Assert.fail(Assert.java:95)
      	at net.mf.presales.AdvantageStepDefinitions.the_mouse_price_is(AdvantageStepDefinitions.java:118)
      	at ?.Then the mouse price is "$9.99"(advantage.feature:10)
      

Failed scenarios:
advantage.feature:15 # Scenario Outline: verify mice color

2 Scenarios (1 failed, 1 passed)
8 Steps (1 failed, 7 passed)
0m27.832s

java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.fail(Assert.java:95)
	at net.mf.presales.AdvantageStepDefinitions.the_mouse_price_is(AdvantageStepDefinitions.java:118)
	at ?.Then the mouse price is "$9.99"(advantage.feature:10)

Tests run: 10, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 29.204 sec <<< FAILURE!
Then the mouse price is "$9.99"(| purple | $9.99 |)  Time elapsed: 0.003 sec  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.fail(Assert.java:95)
	at net.mf.presales.AdvantageStepDefinitions.the_mouse_price_is(AdvantageStepDefinitions.java:118)
	at ✽.Then the mouse price is "$9.99"(advantage.feature:10)

| purple | $9.99 |  Time elapsed: 0.003 sec  <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.fail(Assert.java:95)
	at net.mf.presales.AdvantageStepDefinitions.the_mouse_price_is(AdvantageStepDefinitions.java:118)
	at ✽.Then the mouse price is "$9.99"(advantage.feature:10)


Results :

Failed tests:   Then the mouse price is "$9.99"(| purple | $9.99 |)
  | purple | $9.99 |

Tests run: 10, Failures: 2, Errors: 0, Skipped: 0